### PR TITLE
A patch to allow yaml-cpp to compile with gcc and libcxx

### DIFF
--- a/include/yaml-cpp/node/iterator.h
+++ b/include/yaml-cpp/node/iterator.h
@@ -15,6 +15,8 @@
 #include <utility>
 #include <vector>
 
+static_assert(std::is_constructible<YAML::Node, const YAML::Node&>::value, "Node must be copy constructable");
+
 namespace YAML {
 namespace detail {
 struct iterator_value : public Node, std::pair<Node, Node> {


### PR DESCRIPTION
A copy of https://github.com/jbeder/yaml-cpp/pull/947 changes for this fork.